### PR TITLE
fix migrations to add references rather than integer columns

### DIFF
--- a/db/migrate/20160709181437_create_reservations.rb
+++ b/db/migrate/20160709181437_create_reservations.rb
@@ -1,8 +1,8 @@
 class CreateReservations < ActiveRecord::Migration
   def change
     create_table :reservations do |t|
-      t.integer :user_id
-      t.integer :restaurant_id
+      t.references :user, index: true, foreign_key: true
+      t.references :restaurant, index: true, foreign_key: true
       t.string :email
       t.text :message
       t.date :reservation_date

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,6 +45,9 @@ ActiveRecord::Schema.define(version: 20160709181437) do
     t.datetime "updated_at",       null: false
   end
 
+  add_index "reservations", ["restaurant_id"], name: "index_reservations_on_restaurant_id", using: :btree
+  add_index "reservations", ["user_id"], name: "index_reservations_on_user_id", using: :btree
+
   create_table "restaurants", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
@@ -75,5 +78,7 @@ ActiveRecord::Schema.define(version: 20160709181437) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "reservations", "restaurants"
+  add_foreign_key "reservations", "users"
   add_foreign_key "restaurants", "owners"
 end


### PR DESCRIPTION
I think part of the reason this wasn't working for you was that you were adding the <model>_id columns, but you weren't adding them as a foreign key.  I'm not positive on this, either way this is a preferable way of adding a reference in rails. 
